### PR TITLE
Issue 6

### DIFF
--- a/src/basalt-stack.adb
+++ b/src/basalt-stack.adb
@@ -1,0 +1,89 @@
+--
+--  @summary Generic stack implementation
+--  @author  Alexander Senier
+--  @date    2019-12-02
+--
+--  Copyright (C) 2019 Componolit GmbH
+--
+--  This file is part of Basalt, which is distributed under the terms of the
+--  GNU Affero General Public License version 3.
+--
+
+package body Basalt.Stack
+is
+   pragma Annotate (GNATprove, Terminating, Basalt.Stack);
+
+   ----------
+   -- Size --
+   ----------
+
+   function Size (S : Stack_Type) return Positive is
+     (S.List'Last);
+
+   -----------
+   -- Count --
+   -----------
+
+   function Count (S : Stack_Type) return Natural is
+     (S.Index);
+
+   ----------
+   -- Push --
+   ----------
+
+   procedure Push (S : in out Stack_Type;
+                   E :        Element_Type) is
+   begin
+      S.Index := S.Index + 1;
+      S.List (S.Index) := E;
+   end Push;
+
+   ---------
+   -- Pop --
+   ---------
+
+   procedure Pop (S : in out Stack_Type;
+                  E :    out Element_Type) is
+   begin
+      E := S.List (S.Index);
+      Drop (S);
+   end Pop;
+
+   ----------
+   -- Drop --
+   ----------
+
+   procedure Drop (S : in out Stack_Type) is
+   begin
+      S.Index := S.Index - 1;
+   end Drop;
+
+   -----------
+   -- Reset --
+   -----------
+
+   procedure Reset (S : in out Stack_Type) is
+   begin
+      S.Index := 0;
+   end Reset;
+
+   ----------------
+   -- Initialize --
+   ----------------
+
+   procedure Initialize (S            : out Stack_Type;
+                         Null_Element :     Element_Type)
+   is
+   begin
+      S.Index := 0;
+      --  This would be the correct way to initialize S.List:
+      --     S.List  := (others => Null_Element);
+      --  As this creates a (potentially large) object on the stack, we initialize in a loop. The resulting flow
+      --  error is justified in the spec.
+      for E of S.List loop
+         pragma Loop_Invariant (S.Index = 0);
+         E := Null_Element;
+      end loop;
+   end Initialize;
+
+end Basalt.Stack;

--- a/src/basalt-stack.adb
+++ b/src/basalt-stack.adb
@@ -17,21 +17,21 @@ is
    -- Size --
    ----------
 
-   function Size (S : Stack_Type) return Positive is
+   function Size (S : Context) return Positive is
      (S.List'Last);
 
    -----------
    -- Count --
    -----------
 
-   function Count (S : Stack_Type) return Natural is
+   function Count (S : Context) return Natural is
      (S.Index);
 
    ----------
    -- Push --
    ----------
 
-   procedure Push (S : in out Stack_Type;
+   procedure Push (S : in out Context;
                    E :        Element_Type) is
    begin
       S.Index := S.Index + 1;
@@ -42,7 +42,7 @@ is
    -- Pop --
    ---------
 
-   procedure Pop (S : in out Stack_Type;
+   procedure Pop (S : in out Context;
                   E :    out Element_Type) is
    begin
       E := S.List (S.Index);
@@ -53,7 +53,7 @@ is
    -- Drop --
    ----------
 
-   procedure Drop (S : in out Stack_Type) is
+   procedure Drop (S : in out Context) is
    begin
       S.Index := S.Index - 1;
    end Drop;
@@ -62,7 +62,7 @@ is
    -- Reset --
    -----------
 
-   procedure Reset (S : in out Stack_Type) is
+   procedure Reset (S : in out Context) is
    begin
       S.Index := 0;
    end Reset;
@@ -71,7 +71,7 @@ is
    -- Initialize --
    ----------------
 
-   procedure Initialize (S            : out Stack_Type;
+   procedure Initialize (S            : out Context;
                          Null_Element :     Element_Type)
    is
    begin

--- a/src/basalt-stack.ads
+++ b/src/basalt-stack.ads
@@ -15,78 +15,78 @@ package Basalt.Stack
 is
    pragma Unevaluated_Use_Of_Old (Allow);
 
-   type Stack_Type (Size : Positive) is private;
+   type Context (Size : Positive) is private;
 
-   function Size (S : Stack_Type) return Positive with
-     Annotate => (GNATprove, Inline_For_Proof);
    --  Size of stack
    --
    --  @param S  Stack
    --  @return   Size of stack S
-
-   function Count (S : Stack_Type) return Natural with
+   function Size (S : Context) return Positive with
      Annotate => (GNATprove, Inline_For_Proof);
+
    --  Number of elements on stack
    --
    --  @param S  Stack
    --  @return   Current elements in stack S
-
-   function Is_Empty (S : Stack_Type) return Boolean is (Count (S) = 0) with
+   function Count (S : Context) return Natural with
      Annotate => (GNATprove, Inline_For_Proof);
+
    --  Stack is empty
    --
    --  @param S  Stack
    --  @return   Stack is empty
-
-   function Is_Full (S : Stack_Type) return Boolean is (Count (S) >= Size (S)) with
+   function Is_Empty (S : Context) return Boolean is (Count (S) = 0) with
      Annotate => (GNATprove, Inline_For_Proof);
+
    --  Stack is full
    --
    --  @param S  Stack
    --  @return   Stack is valid
+   function Is_Full (S : Context) return Boolean is (Count (S) >= Size (S)) with
+     Annotate => (GNATprove, Inline_For_Proof);
 
-   procedure Push (S : in out Stack_Type;
-                   E :        Element_Type) with
-     Pre  => not Is_Full (S),
-     Post => Count (S) = Count (S)'Old + 1
-             and then not Is_Empty (S);
    --  Push element onto stack
    --
    --  @param S  Stack
    --  @param E  Element to push onto stack S
+   procedure Push (S : in out Context;
+                   E :        Element_Type) with
+     Pre  => not Is_Full (S),
+     Post => Count (S) = Count (S)'Old + 1
+             and then not Is_Empty (S);
 
-   procedure Pop (S : in out Stack_Type;
-                  E :    out Element_Type) with
-     Pre  => not Is_Empty (S),
-     Post => Count (S) = Count (S)'Old - 1
-             and then not Is_Full (S);
    --  Pop an element off the stack
    --
    --  @param S  Stack
    --  @param E  Result element
-
-   procedure Drop (S : in out Stack_Type) with
+   procedure Pop (S : in out Context;
+                  E :    out Element_Type) with
      Pre  => not Is_Empty (S),
      Post => Count (S) = Count (S)'Old - 1
              and then not Is_Full (S);
+
    --  Drop an element from stack
    --
    --  @param S  Stack
-
-   procedure Reset (S : in out Stack_Type) with
-     Post => Is_Empty (S)
+   procedure Drop (S : in out Context) with
+     Pre  => not Is_Empty (S),
+     Post => Count (S) = Count (S)'Old - 1
              and then not Is_Full (S);
+
    --  Reset stack without erasing data
    --
    --  @param S  Stack
-
-   procedure Initialize (S            : out Stack_Type;
-                         Null_Element :     Element_Type) with
+   procedure Reset (S : in out Context) with
      Post => Is_Empty (S)
              and then not Is_Full (S);
+
    --  Initialize stack and clear stack buffer
    --
    --  @param S  Stack
+   procedure Initialize (S            : out Context;
+                         Null_Element :     Element_Type) with
+     Post => Is_Empty (S)
+             and then not Is_Full (S);
 
    pragma Annotate (GNATprove, False_Positive,
                     """S.List"" might not be initialized*",
@@ -96,7 +96,7 @@ private
 
    type Simple_List is array (Positive range <>) of Element_Type;
 
-   type Stack_Type (Size : Positive) is record
+   type Context (Size : Positive) is record
       Index : Natural;
       List  : Simple_List (1 .. Size);
    end record with

--- a/src/basalt-stack.ads
+++ b/src/basalt-stack.ads
@@ -1,0 +1,105 @@
+--
+--  @summary Generic stack specification
+--  @author  Alexander Senier
+--  @date    2019-12-02
+--
+--  Copyright (C) 2018 Componolit GmbH
+--
+--  This file is part of Basalt, which is distributed under the terms of the
+--  GNU Affero General Public License version 3.
+--
+
+generic
+   type Element_Type is private;
+package Basalt.Stack
+is
+   pragma Unevaluated_Use_Of_Old (Allow);
+
+   type Stack_Type (Size : Positive) is private;
+
+   function Size (S : Stack_Type) return Positive with
+     Annotate => (GNATprove, Inline_For_Proof);
+   --  Size of stack
+   --
+   --  @param S  Stack
+   --  @return   Size of stack S
+
+   function Count (S : Stack_Type) return Natural with
+     Annotate => (GNATprove, Inline_For_Proof);
+   --  Number of elements on stack
+   --
+   --  @param S  Stack
+   --  @return   Current elements in stack S
+
+   function Is_Empty (S : Stack_Type) return Boolean is (Count (S) = 0) with
+     Annotate => (GNATprove, Inline_For_Proof);
+   --  Stack is empty
+   --
+   --  @param S  Stack
+   --  @return   Stack is empty
+
+   function Is_Full (S : Stack_Type) return Boolean is (Count (S) >= Size (S)) with
+     Annotate => (GNATprove, Inline_For_Proof);
+   --  Stack is full
+   --
+   --  @param S  Stack
+   --  @return   Stack is valid
+
+   procedure Push (S : in out Stack_Type;
+                   E :        Element_Type) with
+     Pre  => not Is_Full (S),
+     Post => Count (S) = Count (S)'Old + 1
+             and then not Is_Empty (S);
+   --  Push element onto stack
+   --
+   --  @param S  Stack
+   --  @param E  Element to push onto stack S
+
+   procedure Pop (S : in out Stack_Type;
+                  E :    out Element_Type) with
+     Pre  => not Is_Empty (S),
+     Post => Count (S) = Count (S)'Old - 1
+             and then not Is_Full (S);
+   --  Pop an element off the stack
+   --
+   --  @param S  Stack
+   --  @param E  Result element
+
+   procedure Drop (S : in out Stack_Type) with
+     Pre  => not Is_Empty (S),
+     Post => Count (S) = Count (S)'Old - 1
+             and then not Is_Full (S);
+   --  Drop an element from stack
+   --
+   --  @param S  Stack
+
+   procedure Reset (S : in out Stack_Type) with
+     Post => Is_Empty (S)
+             and then not Is_Full (S);
+   --  Reset stack without erasing data
+   --
+   --  @param S  Stack
+
+   procedure Initialize (S            : out Stack_Type;
+                         Null_Element :     Element_Type) with
+     Post => Is_Empty (S)
+             and then not Is_Full (S);
+   --  Initialize stack and clear stack buffer
+   --
+   --  @param S  Stack
+
+   pragma Annotate (GNATprove, False_Positive,
+                    """S.List"" might not be initialized*",
+                    "Initialized in complete loop");
+
+private
+
+   type Simple_List is array (Positive range <>) of Element_Type;
+
+   type Stack_Type (Size : Positive) is record
+      Index : Natural;
+      List  : Simple_List (1 .. Size);
+   end record with
+     Predicate => Index <= List'Last;
+
+end Basalt.Stack;

--- a/test/aunit/stack_tests.adb
+++ b/test/aunit/stack_tests.adb
@@ -1,0 +1,122 @@
+with Aunit.Assertions;
+with Basalt.Stack;
+
+package body Stack_Tests
+is
+   package F is new Basalt.Stack (Integer);
+
+   procedure Test_Stack (T : in out Aunit.Test_Cases.Test_Case'Class)
+   is
+      pragma Unreferenced (T);
+      Q : F.Stack_Type (100);
+      J : Integer;
+   begin
+      F.Initialize (Q, 0);
+      for I in 70 .. 120 loop
+         F.Push (Q, I);
+      end loop;
+      for I in reverse 70 .. 120 loop
+         F.Pop (Q, J);
+         Aunit.Assertions.Assert (J = I, "Invalid order");
+      end loop;
+   end Test_Stack;
+
+   procedure Test_Full_Empty (T : in out Aunit.Test_Cases.Test_Case'Class)
+   is
+      pragma Unreferenced (T);
+      Q : F.Stack_Type (2);
+   begin
+      F.Initialize (Q, 0);
+      Aunit.Assertions.Assert (F.Count (Q) = 0, "Count not 0");
+      F.Push (Q, 1);
+      Aunit.Assertions.Assert (F.Count (Q) = 1, "Count not 1 after Push");
+      F.Push (Q, 2);
+      Aunit.Assertions.Assert (F.Count (Q) = 2, "Count not 2 after Push");
+      F.Drop (Q);
+      Aunit.Assertions.Assert (F.Count (Q) = 1, "Count not 1 after Drop");
+      F.Drop (Q);
+      Aunit.Assertions.Assert (F.Count (Q) = 0, "Count not 0 after Drop");
+   end Test_Full_Empty;
+
+   procedure Test_Single_Element (T : in out Aunit.Test_Cases.Test_Case'Class)
+   is
+      pragma Unreferenced (T);
+      Q : F.Stack_Type (1);
+      J : Integer;
+   begin
+      F.Initialize (Q, 0);
+      Aunit.Assertions.Assert (F.Is_Empty (Q), "Stack not empty");
+      Aunit.Assertions.Assert (F.Count (Q) = 0, "Stack not empty");
+      F.Push (Q, 1);
+      Aunit.Assertions.Assert (F.Count (Q) = 1, "Stack not full");
+      Aunit.Assertions.Assert (F.Is_Full (Q), "Stack not full");
+      F.Drop (Q);
+      Aunit.Assertions.Assert (F.Is_Empty (Q), "Stack not empty");
+      Aunit.Assertions.Assert (F.Count (Q) = 0, "Stack not empty after drop");
+   end Test_Single_Element;
+
+   procedure Test_Count (T : in out Aunit.Test_Cases.Test_Case'Class)
+   is
+      pragma Unreferenced (T);
+      Q : F.Stack_Type (100);
+   begin
+      F.Initialize (Q, 0);
+      Aunit.Assertions.Assert (F.Count (Q) = 0, "Count should be 0");
+      for I in Integer range 1 .. 20 loop
+         F.Push (Q, I);
+      end loop;
+      Aunit.Assertions.Assert (F.Count (Q) = 20, "Count should be 20");
+      for I in Integer range 1 .. 40 loop
+         F.Push (Q, I);
+      end loop;
+      Aunit.Assertions.Assert (F.Count (Q) = 60, "Count should be 60");
+      for I in Integer range 1 .. 50 loop
+         F.Drop (Q);
+      end loop;
+      Aunit.Assertions.Assert (F.Count (Q) = 10, "Count should be 10");
+      for I in Integer range 1 .. 80 loop
+         F.Push (Q, I);
+      end loop;
+      Aunit.Assertions.Assert (F.Count (Q) = 90, "Count should be 90");
+      for I in Integer range 1 .. 90 loop
+         F.Drop (Q);
+      end loop;
+      Aunit.Assertions.Assert (F.Count (Q) = 0, "Count should be 0");
+   end Test_Count;
+
+   procedure Test_Size (T : in out Aunit.Test_Cases.Test_Case'Class)
+   is
+      pragma Unreferenced (T);
+      Q1 : F.Stack_Type (1);
+      Q2 : F.Stack_Type (50);
+      Q3 : F.Stack_Type (200);
+      Q4 : F.Stack_Type (13000);
+   begin
+      F.Initialize (Q1, 0);
+      F.Initialize (Q2, 0);
+      F.Initialize (Q3, 0);
+      F.Initialize (Q4, 0);
+      Aunit.Assertions.Assert (F.Size (Q1) = 1, "Size of Q1 should be 1");
+      Aunit.Assertions.Assert (F.Size (Q2) = 50, "Size of Q2 should be 50");
+      Aunit.Assertions.Assert (F.Size (Q3) = 200, "Size of Q3 should be 200");
+      Aunit.Assertions.Assert (F.Size (Q4) = 13000, "Size of Q4 should be 13000");
+   end Test_Size;
+
+   procedure Register_Tests (T : in out Test_Case)
+   is
+      use Aunit.Test_Cases.Registration;
+   begin
+      Register_Routine (T, Test_Stack'Access, "Test stack");
+      Register_Routine (T, Test_Full_Empty'Access, "Test full and emtpy");
+      Register_Routine (T, Test_Single_Element'Access, "Test single element");
+      Register_Routine (T, Test_Count'Access, "Test count");
+      Register_Routine (T, Test_Size'Access, "Test size");
+   end Register_Tests;
+
+   function Name (T : Test_Case) return Aunit.Message_String
+   is
+   begin
+      return Aunit.Format ("Basalt.Stack");
+   end Name;
+
+end Stack_Tests;

--- a/test/aunit/stack_tests.adb
+++ b/test/aunit/stack_tests.adb
@@ -8,7 +8,7 @@ is
    procedure Test_Stack (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q : F.Stack_Type (100);
+      Q : F.Context (100);
       J : Integer;
    begin
       F.Initialize (Q, 0);
@@ -24,7 +24,7 @@ is
    procedure Test_Full_Empty (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q : F.Stack_Type (2);
+      Q : F.Context (2);
    begin
       F.Initialize (Q, 0);
       Aunit.Assertions.Assert (F.Count (Q) = 0, "Count not 0");
@@ -41,8 +41,7 @@ is
    procedure Test_Single_Element (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q : F.Stack_Type (1);
-      J : Integer;
+      Q : F.Context (1);
    begin
       F.Initialize (Q, 0);
       Aunit.Assertions.Assert (F.Is_Empty (Q), "Stack not empty");
@@ -58,7 +57,7 @@ is
    procedure Test_Count (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q : F.Stack_Type (100);
+      Q : F.Context (100);
    begin
       F.Initialize (Q, 0);
       Aunit.Assertions.Assert (F.Count (Q) = 0, "Count should be 0");
@@ -87,10 +86,10 @@ is
    procedure Test_Size (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q1 : F.Stack_Type (1);
-      Q2 : F.Stack_Type (50);
-      Q3 : F.Stack_Type (200);
-      Q4 : F.Stack_Type (13000);
+      Q1 : F.Context (1);
+      Q2 : F.Context (50);
+      Q3 : F.Context (200);
+      Q4 : F.Context (13000);
    begin
       F.Initialize (Q1, 0);
       F.Initialize (Q2, 0);

--- a/test/aunit/stack_tests.ads
+++ b/test/aunit/stack_tests.ads
@@ -1,0 +1,12 @@
+with Aunit;
+with Aunit.Test_Cases;
+
+package Stack_Tests
+is
+   type Test_Case is new Aunit.Test_Cases.Test_Case with null record;
+
+   procedure Register_Tests (T : in out Test_Case);
+
+   function Name (T : Test_Case) return Aunit.Message_String;
+
+end Stack_Tests;

--- a/test/aunit/suite.adb
+++ b/test/aunit/suite.adb
@@ -2,6 +2,7 @@
 with Basalt.Strings.Tests;
 with Queue_Tests;
 with Slicer_Tests;
+with Stack_Tests;
 
 package body Suite
 is
@@ -9,8 +10,9 @@ is
    Result : aliased Aunit.Test_Suites.Test_Suite;
 
    Strings_Case : aliased Basalt.Strings.Tests.Test_Case;
-   Queue_Case    : aliased Queue_Tests.Test_Case;
+   Queue_Case   : aliased Queue_Tests.Test_Case;
    Slicer_Case  : aliased Slicer_Tests.Test_Case;
+   Stack_Case   : aliased Stack_Tests.Test_Case;
 
    function Suite return Aunit.Test_Suites.Access_Test_Suite
    is
@@ -18,6 +20,7 @@ is
       Result.Add_Test (Strings_Case'Access);
       Result.Add_Test (Queue_Case'Access);
       Result.Add_Test (Slicer_Case'Access);
+      Result.Add_Test (Stack_Case'Access);
       return Result'Access;
    end Suite;
 

--- a/test/aunit/test.adb
+++ b/test/aunit/test.adb
@@ -10,8 +10,10 @@ is
    use type Aunit.Status;
    function Run is new Aunit.Run.Test_Runner_With_Status (Suite.Suite);
    Reporter : Aunit.Reporter.Text.Text_Reporter;
-   S        : Aunit.Status := Run (Reporter);
+   S        : Aunit.Status;
 begin
+   Reporter.Set_Use_ANSI_Colors (True);
+   S := Run (Reporter);
    if S = Aunit.Success then
       Ada.Command_Line.Set_Exit_Status (Ada.Command_Line.Success);
    else

--- a/test/proof/proof_stack.adb
+++ b/test/proof/proof_stack.adb
@@ -6,7 +6,7 @@ package body Proof_Stack with
 is
 
    package Stack is new Basalt.Stack (Integer);
-   S : Stack.Stack_Type (10);
+   S : Stack.Context (10);
 
    procedure Prove
    is

--- a/test/proof/proof_stack.adb
+++ b/test/proof/proof_stack.adb
@@ -1,0 +1,26 @@
+
+with Basalt.Stack;
+
+package body Proof_Stack with
+   SPARK_Mode
+is
+
+   package Stack is new Basalt.Stack (Integer);
+   S : Stack.Stack_Type (10);
+
+   procedure Prove
+   is
+   begin
+      Stack.Initialize (S, 0);
+      for I in Integer range 7 .. 13 loop
+         Stack.Push (S, I);
+         exit when Stack.Count (S) >= Stack.Size (S);
+      end loop;
+      pragma Assert (Stack.Count (S) = 7);
+      for I in Integer range 1 .. 7 loop
+         Stack.Drop (S);
+      end loop;
+      pragma Assert (Stack.Is_Empty (S));
+   end Prove;
+
+end Proof_Stack;

--- a/test/proof/proof_stack.ads
+++ b/test/proof/proof_stack.ads
@@ -1,0 +1,8 @@
+
+package Proof_Stack with
+   SPARK_Mode
+is
+
+   procedure Prove;
+
+end Proof_Stack;


### PR DESCRIPTION
Port of SXML stack implementation.

Please have a close lock regarding style (esp. whether it matches the rest of the lib). We need to discuss how we name types. A type `Stack` inside a package `Stack` (analogous to Queue) gives a warning when `-gnatwh` (warn about hiding declarations) is enabled. I think we should avoid those.