### PR TITLE
Naming, termination proof, pureness

### DIFF
--- a/src/basalt-queue.adb
+++ b/src/basalt-queue.adb
@@ -13,13 +13,6 @@ package body Basalt.Queue with
    SPARK_Mode
 is
 
-   function Valid (C : Context) return Boolean is
-      (Long_Natural'Last - C.Index > Long_Positive (C.List'First)
-       and then C.Index + Long_Positive (C.List'First) in
-             Long_Positive (C.List'First) .. Long_Positive (C.List'Last)
-       and then Long_Positive'Last - Long_Positive (C.List'Length) >= C.Index
-       and then C.Length <= C.List'Length);
-
    function Size (C : Context) return Positive is (C.List'Length);
 
    function Count (C : Context) return Natural is (Natural (C.Length));
@@ -28,9 +21,15 @@ is
                          Null_Element :     T)
    is
    begin
-      C.List   := (C.List'Range => Null_Element);
-      C.Index  := Long_Natural'First;
+      --  This would be the correct way to initialize S.List:
+      --     C.List  := (others => Null_Element);
+      --  As this creates a (potentially large) object on the stack, we initialize in a loop. The resulting flow
+      --  error is justified in the spec.
+      for E of C.List loop
+         E := Null_Element;
+      end loop;
       C.Length := Long_Natural'First;
+      C.Index  := Long_Natural'First;
    end Initialize;
 
    procedure Put (C       : in out Context;

--- a/src/basalt-queue.adb
+++ b/src/basalt-queue.adb
@@ -13,57 +13,57 @@ package body Basalt.Queue with
    SPARK_Mode
 is
 
-   function Valid (Q : Queue) return Boolean is
-      (Long_Natural'Last - Q.Index > Long_Positive (Q.List'First)
-       and then Q.Index + Long_Positive (Q.List'First) in
-             Long_Positive (Q.List'First) .. Long_Positive (Q.List'Last)
-       and then Long_Positive'Last - Long_Positive (Q.List'Length) >= Q.Index
-       and then Q.Length <= Q.List'Length);
+   function Valid (C : Context) return Boolean is
+      (Long_Natural'Last - C.Index > Long_Positive (C.List'First)
+       and then C.Index + Long_Positive (C.List'First) in
+             Long_Positive (C.List'First) .. Long_Positive (C.List'Last)
+       and then Long_Positive'Last - Long_Positive (C.List'Length) >= C.Index
+       and then C.Length <= C.List'Length);
 
-   function Size (Q : Queue) return Positive is (Q.List'Length);
+   function Size (C : Context) return Positive is (C.List'Length);
 
-   function Count (Q : Queue) return Natural is (Natural (Q.Length));
+   function Count (C : Context) return Natural is (Natural (C.Length));
 
-   procedure Initialize (Q            : out Queue;
+   procedure Initialize (C            : out Context;
                          Null_Element :     T)
    is
    begin
-      Q.List   := (Q.List'Range => Null_Element);
-      Q.Index  := Long_Natural'First;
-      Q.Length := Long_Natural'First;
+      C.List   := (C.List'Range => Null_Element);
+      C.Index  := Long_Natural'First;
+      C.Length := Long_Natural'First;
    end Initialize;
 
-   procedure Put (Q       : in out Queue;
+   procedure Put (C       : in out Context;
                   Element :        T)
    is
       Index : Positive;
    begin
-      Index          := Positive ((Q.Index + Q.Length) mod
-                                     Q.List'Length + Long_Positive (Q.List'First));
-      Q.Length       := Q.Length + 1;
-      Q.List (Index) := Element;
+      Index          := Positive ((C.Index + C.Length) mod
+                                     C.List'Length + Long_Positive (C.List'First));
+      C.Length       := C.Length + 1;
+      C.List (Index) := Element;
    end Put;
 
-   procedure Peek (Q       :     Queue;
+   procedure Peek (C       :     Context;
                    Element : out T)
    is
    begin
-      Element := Q.List (Positive (Q.Index + Long_Positive (Q.List'First)));
+      Element := C.List (Positive (C.Index + Long_Positive (C.List'First)));
    end Peek;
 
-   procedure Drop (Q : in out Queue)
+   procedure Drop (C : in out Context)
    is
    begin
-      Q.Index  := (Q.Index + 1) mod Q.List'Length;
-      Q.Length := Q.Length - 1;
+      C.Index  := (C.Index + 1) mod C.List'Length;
+      C.Length := C.Length - 1;
    end Drop;
 
-   procedure Pop (Q       : in out Queue;
+   procedure Pop (C       : in out Context;
                   Element :    out T)
    is
    begin
-      Peek (Q, Element);
-      Drop (Q);
+      Peek (C, Element);
+      Drop (C);
    end Pop;
 
 end Basalt.Queue;

--- a/src/basalt-queue.ads
+++ b/src/basalt-queue.ads
@@ -26,28 +26,28 @@ is
    --  large type T or large queue sizes.
    --
    --  @param Size  Length of the queue
-   type Queue (Size : Positive) is private;
+   type Context (Size : Positive) is private;
 
    --  Checks if a queue is valid, proof only
    --
-   --  @param Q  Queue
-   --  @return   Q is valid
-   function Valid (Q : Queue) return Boolean with
+   --  @param C  Queue context
+   --  @return   C is valid
+   function Valid (C : Context) return Boolean with
       Ghost;
 
    --  Returns the size of the queue given when instantiated
    --
-   --  @param Q  Queue
+   --  @param C  Queue context
    --  @return   Number of Elements the queue can hold
-   function Size (Q : Queue) return Positive with
-      Pre => Valid (Q);
+   function Size (C : Context) return Positive with
+      Pre => Valid (C);
 
    --  Returns the current length of the queue
    --
-   --  @param Q  Queue
+   --  @param C  Queue context
    --  @return   Number of elements currently in the queue
-   function Count (Q : Queue) return Natural with
-      Pre => Valid (Q);
+   function Count (C : Context) return Natural with
+      Pre => Valid (C);
 
    --  Initializes the queue with a default element value
    --
@@ -55,45 +55,45 @@ is
    --  the only way to assign a Queue object. The object will automatically
    --  be initialized with the given element. The initialized queue will be empty.
    --
-   --  @param Q             Queue
+   --  @param C             Queue context
    --  @param Null_Element  Default element to initialize the queue with
-   procedure Initialize (Q            : out Queue;
+   procedure Initialize (C            : out Context;
                          Null_Element :     T) with
-      Post => Valid (Q) and then Count (Q) = 0;
+      Post => Valid (C) and then Count (C) = 0;
 
    --  Puts an element in the queue.
    --
-   --  @param Q        Queue
+   --  @param C        Queue context
    --  @param Element  Element
-   procedure Put (Q       : in out Queue;
+   procedure Put (C       : in out Context;
                   Element :        T) with
-      Pre  => Valid (Q) and then Count (Q) < Size (Q),
-      Post => Valid (Q) and then Count (Q) = Count (Q'Old) + 1;
+      Pre  => Valid (C) and then Count (C) < Size (C),
+      Post => Valid (C) and then Count (C) = Count (C'Old) + 1;
 
    --  Check the current first element, does not alter the queue
    --
-   --  @param Q        Queue
+   --  @param C        Queue context
    --  @param Element  Head of the queue
-   procedure Peek (Q       :     Queue;
+   procedure Peek (C       :     Context;
                    Element : out T) with
-      Pre => Valid (Q) and then Count (Q) > 0;
+      Pre => Valid (C) and then Count (C) > 0;
 
    --  Drop the current first element
    --
-   --  @param Q  Queue
-   procedure Drop (Q : in out Queue) with
-      Pre  => Valid (Q) and then Count (Q) > 0,
-      Post => Valid (Q) and then Count (Q) = Count (Q'Old) - 1;
+   --  @param C  Queue context
+   procedure Drop (C : in out Context) with
+      Pre  => Valid (C) and then Count (C) > 0,
+      Post => Valid (C) and then Count (C) = Count (C'Old) - 1;
 
    --  Get the first element of the queue and drop it,
    --  equivalent to subsequent calls to Peek and Drop
    --
-   --  @param Q        Queue
+   --  @param C        Queue context
    --  @param Element  First element of the queue, will be dropped
-   procedure Pop (Q       : in out Queue;
+   procedure Pop (C       : in out Context;
                   Element :    out T) with
-      Pre  => Valid (Q) and then Count (Q) > 0,
-      Post => Valid (Q) and then Count (Q) = Count (Q'Old) - 1;
+      Pre  => Valid (C) and then Count (C) > 0,
+      Post => Valid (C) and then Count (C) = Count (C'Old) - 1;
 
 private
 
@@ -101,7 +101,7 @@ private
    subtype Long_Natural is Long_Integer range 0 .. Long_Integer'Last;
    subtype Long_Positive is Long_Integer range 1 .. Long_Integer'Last;
 
-   type Queue (Size : Positive) is record
+   type Context (Size : Positive) is record
       Index  : Long_Natural;
       Length : Long_Natural;
       List   : Simple_List (1 .. Size);

--- a/src/basalt-queue.ads
+++ b/src/basalt-queue.ads
@@ -16,7 +16,8 @@ generic
    type T is private;
 package Basalt.Queue with
    SPARK_Mode,
-   Pure
+   Pure,
+   Annotate => (GNATprove, Terminating)
 is
 
    --  Queue storage type

--- a/src/basalt-queue.ads
+++ b/src/basalt-queue.ads
@@ -15,7 +15,8 @@
 generic
    type T is private;
 package Basalt.Queue with
-   SPARK_Mode
+   SPARK_Mode,
+   Pure
 is
 
    --  Queue storage type

--- a/src/basalt-slicer.ads
+++ b/src/basalt-slicer.ads
@@ -19,7 +19,8 @@ generic
    type Index is range <>;
 package Basalt.Slicer with
    SPARK_Mode,
-   Pure
+   Pure,
+   Annotate => (GNATprove, Terminating)
 is
 
    --  Slicer context

--- a/src/basalt-slicer.ads
+++ b/src/basalt-slicer.ads
@@ -18,7 +18,8 @@
 generic
    type Index is range <>;
 package Basalt.Slicer with
-   SPARK_Mode
+   SPARK_Mode,
+   Pure
 is
 
    --  Slicer context

--- a/src/basalt-stack.ads
+++ b/src/basalt-stack.ads
@@ -13,7 +13,8 @@ generic
    type Element_Type is private;
 package Basalt.Stack with
    SPARK_Mode,
-   Pure
+   Pure,
+   Annotate => (GNATprove, Terminating)
 is
    pragma Unevaluated_Use_Of_Old (Allow);
 

--- a/src/basalt-stack.ads
+++ b/src/basalt-stack.ads
@@ -11,7 +11,9 @@
 
 generic
    type Element_Type is private;
-package Basalt.Stack
+package Basalt.Stack with
+   SPARK_Mode,
+   Pure
 is
    pragma Unevaluated_Use_Of_Old (Allow);
 

--- a/src/basalt-strings.ads
+++ b/src/basalt-strings.ads
@@ -14,7 +14,8 @@ with Basalt.Strings_Generic;
 
 package Basalt.Strings with
    SPARK_Mode,
-   Pure
+   Pure,
+   Annotate => (GNATprove, Terminating)
 is
 
    --  Image instances for the most common ranged and modular types

--- a/src/basalt-strings.ads
+++ b/src/basalt-strings.ads
@@ -13,7 +13,8 @@ with Interfaces;
 with Basalt.Strings_Generic;
 
 package Basalt.Strings with
-   SPARK_Mode
+   SPARK_Mode,
+   Pure
 is
 
    --  Image instances for the most common ranged and modular types

--- a/src/basalt-strings_generic.ads
+++ b/src/basalt-strings_generic.ads
@@ -10,7 +10,8 @@
 --
 
 package Basalt.Strings_Generic with
-   SPARK_Mode
+   SPARK_Mode,
+   Pure
 is
 
    type Base is new Integer range 2 .. 16;

--- a/src/basalt-strings_generic.ads
+++ b/src/basalt-strings_generic.ads
@@ -11,7 +11,8 @@
 
 package Basalt.Strings_Generic with
    SPARK_Mode,
-   Pure
+   Pure,
+   Annotate => (GNATprove, Terminating)
 is
 
    type Base is new Integer range 2 .. 16;

--- a/src/basalt.ads
+++ b/src/basalt.ads
@@ -9,6 +9,9 @@
 --  GNU Affero General Public License version 3.
 --
 
-package Basalt is
+package Basalt with
+   SPARK_Mode,
+   Pure
+is
 
 end Basalt;

--- a/test/aunit/queue_tests.adb
+++ b/test/aunit/queue_tests.adb
@@ -9,7 +9,7 @@ is
    procedure Test_Fifo (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q : F.Queue (100);
+      Q : F.Context (100);
       J : Integer;
    begin
       F.Initialize (Q, 0);
@@ -25,7 +25,7 @@ is
    procedure Test_Full_Empty (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q : F.Queue (2);
+      Q : F.Context (2);
    begin
       F.Initialize (Q, 0);
       Aunit.Assertions.Assert (F.Count (Q) = 0, "Count not 0");
@@ -42,7 +42,7 @@ is
    procedure Test_Single_Element (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q : F.Queue (1);
+      Q : F.Context (1);
       J : Integer;
    begin
       F.Initialize (Q, 0);
@@ -58,7 +58,7 @@ is
    procedure Test_Count (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q : F.Queue (100);
+      Q : F.Context (100);
    begin
       F.Initialize (Q, 0);
       Aunit.Assertions.Assert (F.Count (Q) = 0, "Count should be 0");
@@ -87,10 +87,10 @@ is
    procedure Test_Size (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q1 : F.Queue (1);
-      Q2 : F.Queue (50);
-      Q3 : F.Queue (200);
-      Q4 : F.Queue (13000);
+      Q1 : F.Context (1);
+      Q2 : F.Context (50);
+      Q3 : F.Context (200);
+      Q4 : F.Context (13000);
    begin
       F.Initialize (Q1, 0);
       F.Initialize (Q2, 0);
@@ -105,7 +105,7 @@ is
    procedure Test_Overflow (T : in out Aunit.Test_Cases.Test_Case'Class)
    is
       pragma Unreferenced (T);
-      Q : F.Queue (10);
+      Q : F.Context (10);
       J : Integer;
    begin
       F.Initialize (Q, 0);

--- a/test/proof/proof_queue.adb
+++ b/test/proof/proof_queue.adb
@@ -6,7 +6,7 @@ package body Proof_Queue with
 is
 
    package Fifo is new Basalt.Queue (Integer);
-   Queue : Fifo.Queue (10);
+   Queue : Fifo.Context (10);
 
    procedure Prove
    is

--- a/test/proof/proof_queue.adb
+++ b/test/proof/proof_queue.adb
@@ -10,7 +10,7 @@ is
 
    procedure Prove
    is
-      J : Integer;
+      J_Ignore : Integer;
    begin
       Fifo.Initialize (Queue, 0);
       for I in Integer range 7 .. 13 loop
@@ -19,7 +19,7 @@ is
       end loop;
       pragma Assert (Fifo.Count (Queue) = 7);
       for I in Integer range 1 .. 7 loop
-         Fifo.Pop (Queue, J);
+         Fifo.Pop (Queue, J_Ignore);
       end loop;
    end Prove;
 


### PR DESCRIPTION
This fixed #9, #10 and #11. Furthermore it fixes the unused warning for `J` in the Queue proof and replaces the `Queue.Valid` ghost function with a predicate on the `Context` type.