### PR TITLE
Add Split

### DIFF
--- a/src/basalt-queue.ads
+++ b/src/basalt-queue.ads
@@ -18,7 +18,7 @@ generic
 package Basalt.Queue with
    SPARK_Mode,
    Pure,
-   Annotate => (GNATprove, Terminating)
+   Annotate => (GNATprove, Always_Return)
 is
 
    --  Queue storage type

--- a/src/basalt-slicer.ads
+++ b/src/basalt-slicer.ads
@@ -20,7 +20,7 @@ generic
 package Basalt.Slicer with
    SPARK_Mode,
    Pure,
-   Annotate => (GNATprove, Terminating)
+   Annotate => (GNATprove, Always_Return)
 is
 
    --  Slicer context

--- a/src/basalt-stack.adb
+++ b/src/basalt-stack.adb
@@ -11,7 +11,7 @@
 
 package body Basalt.Stack
 is
-   pragma Annotate (GNATprove, Terminating, Basalt.Stack);
+   pragma Annotate (GNATprove, Always_Return, Basalt.Stack);
 
    ----------
    -- Size --

--- a/src/basalt-stack.ads
+++ b/src/basalt-stack.ads
@@ -15,7 +15,7 @@ generic
 package Basalt.Stack with
    SPARK_Mode,
    Pure,
-   Annotate => (GNATprove, Terminating)
+   Annotate => (GNATprove, Always_Return)
 is
    pragma Unevaluated_Use_Of_Old (Allow);
 

--- a/src/basalt-strings.adb
+++ b/src/basalt-strings.adb
@@ -72,4 +72,39 @@ is
       end;
    end Image;
 
+   procedure Split (Value     :     String;
+                    Delimiter :     Character;
+                    Head      : out String_Slice;
+                    Tail      : out String_Slice)
+   is
+   begin
+      Head := String_Slice'(Valid => False);
+      Tail := String_Slice'(Valid => False);
+      for I in Value'Range loop
+         if Value (I) = Delimiter then
+            if I > Value'First then
+               Head := String_Slice'(Valid => True,
+                                     First => Value'First,
+                                     Last  => I - 1);
+            end if;
+            if I < Value'Last then
+               Tail := String_Slice'(Valid => True,
+                                     First => I + 1,
+                                     Last  => Value'Last);
+            end if;
+            return;
+         end if;
+         pragma Loop_Invariant (not Head.Valid);
+         pragma Loop_Invariant (not Tail.Valid);
+         pragma Loop_Invariant (Delimiter /= Value (I));
+         pragma Loop_Invariant (for all J in Value'First .. I => Value (J) /= Delimiter);
+      end loop;
+      pragma Assert (for all I in Value'Range => Value (I) /= Delimiter);
+      if Value'Length > 0 then
+         Head := String_Slice'(Valid => True,
+                               First => Value'First,
+                               Last  => Value'Last);
+      end if;
+   end Split;
+
 end Basalt.Strings;

--- a/src/basalt-strings.ads
+++ b/src/basalt-strings.ads
@@ -50,4 +50,30 @@ is
    package Value_Natural is new Strings_Generic.Value_Option_Ranged (Natural);
    package Value_Positive is new Strings_Generic.Value_Option_Ranged (Positive);
 
+   type String_Slice (Valid : Boolean := False) is record
+      case Valid is
+         when True =>
+            First : Natural;
+            Last  : Natural;
+         when False =>
+            null;
+      end case;
+   end record;
+
+   --  Split a string into a head and tail part based on a delimiting character
+   --
+   --  @param Value  String to split
+   --  @param Delimiter  Delimiting character
+   --  @param Head Range in Value before Delimiter, excluding Delimiter
+   --  @param Tail Range in Value after Delimiter, excluding first Delimiter
+   procedure Split (Value     :     String;
+                    Delimiter :     Character;
+                    Head      : out String_Slice;
+                    Tail      : out String_Slice) with
+      Pre  => not Head'Constrained and not Tail'Constrained,
+      Post => (Value'Length > 0 and then Delimiter /= Value (Value'First)) = Head.Valid
+              and then (for some I in Value'Range => Value (I) = Delimiter and then I /= Value'Last) = Tail.Valid
+              and then (if Tail.Valid then Tail.First in Value'Range and then Tail.Last in Value'Range)
+              and then (if Head.Valid then Head.First in Value'Range and then Head.Last in Value'Range);
+
 end Basalt.Strings;

--- a/src/basalt-strings.ads
+++ b/src/basalt-strings.ads
@@ -15,7 +15,7 @@ with Basalt.Strings_Generic;
 package Basalt.Strings with
    SPARK_Mode,
    Pure,
-   Annotate => (GNATprove, Terminating)
+   Annotate => (GNATprove, Always_Return)
 is
 
    --  Image instances for the most common ranged and modular types

--- a/src/basalt-strings_generic.ads
+++ b/src/basalt-strings_generic.ads
@@ -12,7 +12,7 @@
 package Basalt.Strings_Generic with
    SPARK_Mode,
    Pure,
-   Annotate => (GNATprove, Terminating)
+   Annotate => (GNATprove, Always_Return)
 is
 
    type Residue_Class_Ring is new Integer range 0 .. 16;

--- a/test/aunit/basalt-strings-tests.adb
+++ b/test/aunit/basalt-strings-tests.adb
@@ -225,6 +225,55 @@ is
       Aunit.Assertions.Assert (Value_Integer.Value ("4_2").Value'Img, " 42", "Invalid Value");
    end Test_Value_Formats;
 
+   procedure Test_Split (T : in out Aunit.Test_Cases.Test_Case'Class)
+   is
+      pragma Unreferenced (T);
+      Empty : constant String (1 .. 0) := (others => Character'First);
+      Head  : String_Slice;
+      Tail  : String_Slice;
+      Non_Standard_Range : constant String (42 .. 50) := ("abcd efgh");
+   begin
+      Split ("123,123", ',', Head, Tail);
+      AUnit.Assertions.Assert (Head.Valid, "Head not valid");
+      AUnit.Assertions.Assert (Head.First'Img, " 1", "Invalid Head.First");
+      AUnit.Assertions.Assert (Head.Last'Img, " 3", "Invalid Head.Last");
+      AUnit.Assertions.Assert (Tail.Valid, "Tail not Valid");
+      AUnit.Assertions.Assert (Tail.First'Img, " 5", "Invalid Tail.First");
+      AUnit.Assertions.Assert (Tail.Last'Img, " 7", "Invalid Tail.Last");
+      Split ("123,123,,", ',', Head, Tail);
+      AUnit.Assertions.Assert (Head.Valid, "Head not valid");
+      AUnit.Assertions.Assert (Head.First'Img, " 1", "Invalid Head.First");
+      AUnit.Assertions.Assert (Head.Last'Img, " 3", "Invalid Head.Last");
+      AUnit.Assertions.Assert (Tail.Valid, "Tail not Valid");
+      AUnit.Assertions.Assert (Tail.First'Img, " 5", "Invalid Tail.First");
+      AUnit.Assertions.Assert (Tail.Last'Img, " 9", "Invalid Tail.Last");
+      Split (Empty, Character'First, Head, Tail);
+      AUnit.Assertions.Assert (not Head.Valid, "Head valid");
+      AUnit.Assertions.Assert (not Tail.Valid, "Tail valid");
+      Split ("123,", ',', Head, Tail);
+      AUnit.Assertions.Assert (Head.Valid, "Head not valid");
+      AUnit.Assertions.Assert (Head.First'Img, " 1", "Invalid Head.First");
+      AUnit.Assertions.Assert (Head.Last'Img, " 3", "Invalid Head.Last");
+      AUnit.Assertions.Assert (not Tail.Valid, "Tail valid");
+      Split ("123", ',', Head, Tail);
+      AUnit.Assertions.Assert (Head.Valid, "Head not valid");
+      AUnit.Assertions.Assert (Head.First'Img, " 1", "Invalid Head.First");
+      AUnit.Assertions.Assert (Head.Last'Img, " 3", "Invalid Head.Last");
+      AUnit.Assertions.Assert (not Tail.Valid, "Tail valid");
+      Split (",123,", ',', Head, Tail);
+      AUnit.Assertions.Assert (not Head.Valid, "Head valid");
+      AUnit.Assertions.Assert (Tail.Valid, "Tail not valid");
+      AUnit.Assertions.Assert (Tail.First'Img, " 2", "Invalid Tail.First");
+      AUnit.Assertions.Assert (Tail.Last'Img, " 5", "Invalid Tail.Last");
+      Split (Non_Standard_Range, ' ', Head, Tail);
+      AUnit.Assertions.Assert (Head.Valid, "Head not valid");
+      AUnit.Assertions.Assert (Head.First'Img, " 42", "Invalid Head.First");
+      AUnit.Assertions.Assert (Head.Last'Img, " 45", "Invalid Head.Last");
+      AUnit.Assertions.Assert (Tail.Valid, "Tail not Valid");
+      AUnit.Assertions.Assert (Tail.First'Img, " 47", "Invalid Tail.First");
+      AUnit.Assertions.Assert (Tail.Last'Img, " 50", "Invalid Tail.Last");
+   end Test_Split;
+
    procedure Register_Tests (T : in out Test_Case)
    is
       use Aunit.Test_Cases.Registration;
@@ -244,6 +293,7 @@ is
       Register_Routine (T, Test_Value_Ranged_Int'Access, "Test Value Integers");
       Register_Routine (T, Test_Value_Ranged_Ranges'Access, "Test Value Ranges");
       Register_Routine (T, Test_Value_Formats'Access, "Test Value Formats");
+      Register_Routine (T, Test_Split'Access, "Test Split");
    end Register_Tests;
 
    function Name (T : Test_Case) return Aunit.Message_String


### PR DESCRIPTION
Add `Split` procedure for strings that allows to split a string at a given delimiter with a Gold level proof.